### PR TITLE
Net5.0

### DIFF
--- a/src/aspen/Aspen.sln
+++ b/src/aspen/Aspen.sln
@@ -9,27 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "aspen.api", "aspen.api\aspe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "aspen.tests", "aspen.tests\aspen.tests.csproj", "{508E7095-F36A-4DBA-A5ED-30E4435982C1}"
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "aspen.web", "aspen.web\", "{13147DAA-FAF8-4503-8689-8920065C6E33}"
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.0"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_52681"
-		Debug.AspNetCompiler.PhysicalPath = "aspen.web\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_52681\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_52681"
-		Release.AspNetCompiler.PhysicalPath = "aspen.web\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_52681\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "52681"
-		SlnRelativePath = "aspen.web\"
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9E117319-8FCB-4711-AF2A-EB2A44D6A58E}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
@@ -55,10 +34,6 @@ Global
 		{508E7095-F36A-4DBA-A5ED-30E4435982C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{508E7095-F36A-4DBA-A5ED-30E4435982C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{508E7095-F36A-4DBA-A5ED-30E4435982C1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{13147DAA-FAF8-4503-8689-8920065C6E33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{13147DAA-FAF8-4503-8689-8920065C6E33}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{13147DAA-FAF8-4503-8689-8920065C6E33}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{13147DAA-FAF8-4503-8689-8920065C6E33}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/aspen/aspen.api/Controllers/CharityController.cs
+++ b/src/aspen/aspen.api/Controllers/CharityController.cs
@@ -60,7 +60,7 @@ namespace Aspen.Api.Controllers
         private Result<Guid> validateCharityId(Guid id) => Result<Guid>.Success(id);
 
         [HttpGet("gethomepage")]
-        public async Task<ApiResult> GetHomePage([FromQuery(Name = "charityId")] Guid charityId)
+        public ApiResult GetHomePage([FromQuery(Name = "charityId")] Guid charityId)
         {
             const string loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
             return ApiResult.Success(new HomePage(loremIpsum));

--- a/src/aspen/aspen.api/Controllers/CharityController.cs
+++ b/src/aspen/aspen.api/Controllers/CharityController.cs
@@ -52,8 +52,7 @@ namespace Aspen.Api.Controllers
 
         [HttpGet("gettheme")]
         public async Task<ApiResult> GetTheme([FromQuery(Name = "charityId")] Guid charityId) =>
-            await charityId
-                .ValidateFunction(id => Result<Guid>.Success(id))
+            await new Result<Guid>(charityId)
                 .ApplyAsync(charityRepository.GetById)
                 .ApplyAsync(themeRepository.GetByCharity)
                 .ReturnApiResult();

--- a/src/aspen/aspen.api/Dockerfile
+++ b/src/aspen/aspen.api/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS base
 WORKDIR /app
 EXPOSE 5000
 EXPOSE 5001
@@ -8,7 +8,7 @@ RUN adduser -h /app app -D -s /usr/sbin/nologin
 RUN mkdir -p /app/.postgresql
 RUN chmod 700 /app/.postgresql
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /src
 COPY ["aspen.api/aspen.api.csproj", "aspen.api/"]
 COPY ["aspen.core/aspen.core.csproj", "aspen.core/"]

--- a/src/aspen/aspen.api/ProductionStartupVersion.cs
+++ b/src/aspen/aspen.api/ProductionStartupVersion.cs
@@ -24,7 +24,6 @@ namespace Aspen.Api
 {
     public class ProductionStartupVersion
     {
-        readonly string MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
         private ConnectionString connectionString;
 
         public IConfiguration Configuration { get; }

--- a/src/aspen/aspen.api/Startup.cs
+++ b/src/aspen/aspen.api/Startup.cs
@@ -24,7 +24,6 @@ namespace Aspen.Api
 {
     public class Startup
     {
-        readonly string MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
         private ConnectionString connectionString;
 
         public IConfiguration Configuration { get; }

--- a/src/aspen/aspen.api/aspen.api.csproj
+++ b/src/aspen/aspen.api/aspen.api.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentMigrator" Version="3.2.1" />
-    <PackageReference Include="FluentMigrator.Runner" Version="3.2.1" />
-    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Npgsql" Version="4.1.3.1" />
+    <PackageReference Include="FluentMigrator" Version="3.2.11" />
+    <PackageReference Include="FluentMigrator.Runner" Version="3.2.11" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.2.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
+    <PackageReference Include="Npgsql" Version="5.0.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/aspen/aspen.api/aspen.api.csproj
+++ b/src/aspen/aspen.api/aspen.api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>8a6d8d07-2e98-4293-981f-195c878052b8</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>

--- a/src/aspen/aspen.core/Repositories/AdminUserRepository.cs
+++ b/src/aspen/aspen.core/Repositories/AdminUserRepository.cs
@@ -30,7 +30,7 @@ namespace Aspen.Core.Repositories
 
                     return Result<bool>.Success(true);
                 }
-                catch(Npgsql.PostgresException e)
+                catch(Npgsql.PostgresException)
                 {
                     return Result<bool>.Failure("User already exists in database");
                 }
@@ -52,7 +52,7 @@ namespace Aspen.Core.Repositories
                     );
                     return Result<User>.Success(user);
                 }
-                catch(System.InvalidOperationException e)
+                catch(System.InvalidOperationException)
                 {
                     return Result<User>.Failure("User does not exist in database");
                 }

--- a/src/aspen/aspen.core/Result.cs
+++ b/src/aspen/aspen.core/Result.cs
@@ -42,36 +42,19 @@ namespace Aspen.Core
             return await func(state);
         }
 
-        public static Result<U> Apply<U, T>(this Result<T> result, Func<T, Result<U>> func)
-        {
-            if (result.IsSucccess)
+        public static Result<U> Apply<U, T>(this Result<T> result, Func<T, Result<U>> func) =>
+            result.IsSucccess switch
             {
-                return func(result.State);
-            }
-            else
-            {
-                return Result<U>.Failure(result.Error);
-            }
+                true => func(result.State),
+                false => Result<U>.Failure(result.Error)
+            };
 
-            //Once we can use C# 9 (on .net 5) 
-            // return result.IsSucccess switch
-            // {
-            //     true => func(result.State)
-            //     false => Result<U>.Failure(result.Error);
-            // }
-        }
-
-        public static async Task<Result<U>> ApplyAsync<U, T>(this Result<T> result, Func<T, Task<Result<U>>> func)
-        {
-            if (result.IsSucccess)
+        public static async Task<Result<U>> ApplyAsync<U, T>(this Result<T> result, Func<T, Task<Result<U>>> func) =>
+            result.IsSucccess switch
             {
-                return await func(result.State);
-            }
-            else
-            {
-                return Result<U>.Failure(result.Error);
-            }
-        }
+                true => await func(result.State),
+                false => Result<U>.Failure(result.Error)
+            };
 
         public static async Task<Result<U>> ApplyAsync<U, T>(this Task<Result<T>> task, Func<T, Task<Result<U>>> func)
         {

--- a/src/aspen/aspen.core/Result.cs
+++ b/src/aspen/aspen.core/Result.cs
@@ -7,6 +7,13 @@ namespace Aspen.Core
     //maybe rename to internalresult
     public struct Result<T>
     {
+        public Result(T state)
+        {
+            IsSucccess = true;
+            State = state;
+            Error = null;
+        }
+
         public bool IsFailure => !IsSucccess;
         public bool IsSucccess { get; }
         public T State { get; }
@@ -15,8 +22,8 @@ namespace Aspen.Core
         private Result(bool IsSucccess, T state, string error)
         {
             this.IsSucccess = IsSucccess;
-            this.State = state;
-            this.Error = error;
+            State = state;
+            Error = error;
         }
 
         public static Result<T> Success(T state) => new Result<T>(true, state, null);
@@ -45,6 +52,13 @@ namespace Aspen.Core
             {
                 return Result<U>.Failure(result.Error);
             }
+
+            //Once we can use C# 9 (on .net 5) 
+            // return result.IsSucccess switch
+            // {
+            //     true => func(result.State)
+            //     false => Result<U>.Failure(result.Error);
+            // }
         }
 
         public static async Task<Result<U>> ApplyAsync<U, T>(this Result<T> result, Func<T, Task<Result<U>>> func)

--- a/src/aspen/aspen.core/Services/MigrationService.cs
+++ b/src/aspen/aspen.core/Services/MigrationService.cs
@@ -12,7 +12,7 @@ namespace Aspen.Core.Services
 
     public class MigrationService : IMigrationService
     {
-        private readonly bool secure;
+        private readonly bool secure = false;
 
         private ConnectionString adminConnectionString { get; }
 

--- a/src/aspen/aspen.core/aspen.core.csproj
+++ b/src/aspen/aspen.core/aspen.core.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="FluentMigrator" Version="3.2.1" />
-    <PackageReference Include="FluentMigrator.Runner" Version="3.2.1" />
-    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.2.1" />
+    <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="FluentMigrator" Version="3.2.11" />
+    <PackageReference Include="FluentMigrator.Runner" Version="3.2.11" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="3.2.11" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Npgsql" Version="4.1.3.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
+    <PackageReference Include="Npgsql" Version="5.0.1.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/aspen/aspen.core/aspen.core.csproj
+++ b/src/aspen/aspen.core/aspen.core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>Aspen.Core</AssemblyName>
   </PropertyGroup>
 

--- a/src/aspen/aspen.tests/aspen.tests.csproj
+++ b/src/aspen/aspen.tests/aspen.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/aspen/aspen.tests/aspen.tests.csproj
+++ b/src/aspen/aspen.tests/aspen.tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.15.2" />
+    <PackageReference Include="nunit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Two changes:
1) Add a constructor to the Result<T> class that allows you to bypass ValidateFunction() if you don't need to actually validate anything.
2) Upgrade to .NET 5.0