### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/project-aspen/fb921916-451a-4fee-929f-d6e360736c63/46676c9b-c873-4bc2-9263-bb7433a34c0d/_apis/work/boardbadge/14353064-91dd-4d59-b6c8-8915ab865825)](https://dev.azure.com/project-aspen/fb921916-451a-4fee-929f-d6e360736c63/_boards/board/t/46676c9b-c873-4bc2-9263-bb7433a34c0d/Microsoft.RequirementCategory)
 ![Staging Status](https://github.com/SnowSE/project_aspen/actions/workflows/deploy-staging.yml/badge.svg)
 
 # Project Aspen


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/project-aspen/fb921916-451a-4fee-929f-d6e360736c63/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.