### PR TITLE
Text and icon changes

### DIFF
--- a/src/combined/ClientApp/src/ComponentStyling.css
+++ b/src/combined/ClientApp/src/ComponentStyling.css
@@ -385,7 +385,11 @@
 }
 .EventDetailsButton { 
     background-color: var(--SiteMainBtnBgColor) !important;
-    white-space: pre !important;
+    white-space: pre-line !important;
+}
+.EventDetailsButton:hover {
+    background-color: var(--SiteMainBtnHoverColor) !important;
+    white-space: pre-line !important;
 }
 
 /* Create Team Page */

--- a/src/combined/ClientApp/src/ComponentStyling.css
+++ b/src/combined/ClientApp/src/ComponentStyling.css
@@ -383,6 +383,10 @@
 .CreateTeamButtonDetails:hover {
     background-color: var(--SiteMainBtnHoverColor) !important;
 }
+.EventDetailsButton { 
+    background-color: var(--SiteMainBtnBgColor) !important;
+    white-space: pre !important;
+}
 
 /* Create Team Page */
 

--- a/src/combined/ClientApp/src/Pages/EditTeam/EditTeam.tsx
+++ b/src/combined/ClientApp/src/Pages/EditTeam/EditTeam.tsx
@@ -66,7 +66,7 @@ const EditTeam = () => {
         };
         callServise();
         
-    }, [currentTeamUrl]);
+    }, [currentTeamUrl, baseImageUrl, config.headers, currentTeam?.mainImage]);
 
     const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();

--- a/src/combined/ClientApp/src/Pages/Home/Home.tsx
+++ b/src/combined/ClientApp/src/Pages/Home/Home.tsx
@@ -110,9 +110,6 @@ export function Home() {
         setOpenConfrimModal(true)
         setMessage("Are you sure you want to create a new team? This will remove you from the current team you are on.")
     }
-    const OpenEventDetailsOkModal = () => {
-        setOpenEventDetailsOkModal(true);
-    }
     
 
     const getDonationTotal = useCallback(async () => {
@@ -141,25 +138,7 @@ export function Home() {
                     <Typography data-testid={"homePageHeader"} id={"homePageHeader"} className="CurrentEventTextDetails">
                         {currentEvent?.title}
                     </Typography>
-                    <Box>
-                        <Button variant='contained'
-                            onClick={() => {
-                                setMessage(currentEvent?.title +
-                                    <ul>
-                                        <li>currentEvent?.location</li>
-                                        <li>currentEvent?.description</li>
-                                    </ul>)
-                            }}>
-                            Event Details
-                        </Button>
-                        <DynamicModal
-                            open={openEventDetailsOkModal}
-                            close={closeModal}
-                            message={message}
-                            onConfirm={() => navigate('/createteam')}
-                            isOkConfirm={isOkModal}
-                        />
-                    </Box>
+                    
                 </Box>
                 <Box>
                 </Box>
@@ -180,9 +159,34 @@ export function Home() {
                     )}
                 </Box>
                 <Box className="DonateButtonPosition">
+                    
                     <SharingButtonCustomLink
                     defaultMessage='Come look at this awesome event happening.'
                     defaultSubject='Awesome Charity Event' />
+                    <Box sx={{ ml: "10px"}}>
+                        <Button variant='contained'
+                            className = "EventDetailsButton"
+                            onClick={() => {
+                                setMessage("Event: " + currentEvent?.title + "," +
+                                        " Location: " + 
+                                    currentEvent?.location + "," +
+                                    " Description: " + 
+                                    currentEvent?.description
+                                    )
+                                setIsOkModal(true)
+                                setOpenEventDetailsOkModal(true)
+                            }}>
+                            Event Details
+                        </Button>
+                        <DynamicModal
+                            open={openEventDetailsOkModal}
+                            close={closeModal}
+                            message={message}
+                            onConfirm={closeModal}
+                            isOkConfirm={isOkModal}
+                        />
+                    </Box>
+
                     <DonateButton />
                 </Box>
 

--- a/src/combined/ClientApp/src/Pages/Home/Home.tsx
+++ b/src/combined/ClientApp/src/Pages/Home/Home.tsx
@@ -41,6 +41,7 @@ export function Home() {
     const [onATeam, setOnATeam] = useState<boolean>(false);
     const [currentTeam, setCurrentTeam] = useState<any>();
     const [openConfrimModal, setOpenConfrimModal] = useState(false)
+    const [openEventDetailsOkModal, setOpenEventDetailsOkModal] = useState(false)
     const [isOkModal, setIsOkModal] = useState(false)
     const [message, setMessage] = useState("")
 
@@ -83,6 +84,7 @@ export function Home() {
             })
 
         }
+        
 
         const callServise = async () => {
             await getUser();
@@ -98,14 +100,20 @@ export function Home() {
     const closeModal = () => {
         setIsOkModal(false)
         setOpenConfrimModal(false)
+        setOpenEventDetailsOkModal(false)
         setMessage("")
     }
 
     const openModal = () => {
         setIsOkModal(false)
+        setOpenEventDetailsOkModal(false)
         setOpenConfrimModal(true)
         setMessage("Are you sure you want to create a new team? This will remove you from the current team you are on.")
     }
+    const OpenEventDetailsOkModal = () => {
+        setOpenEventDetailsOkModal(true);
+    }
+    
 
     const getDonationTotal = useCallback(async () => {
         try {
@@ -133,6 +141,27 @@ export function Home() {
                     <Typography data-testid={"homePageHeader"} id={"homePageHeader"} className="CurrentEventTextDetails">
                         {currentEvent?.title}
                     </Typography>
+                    <Box>
+                        <Button variant='contained'
+                            onClick={() => {
+                                setMessage(currentEvent?.title +
+                                    <ul>
+                                        <li>currentEvent?.location</li>
+                                        <li>currentEvent?.description</li>
+                                    </ul>)
+                            }}>
+                            Event Details
+                        </Button>
+                        <DynamicModal
+                            open={openEventDetailsOkModal}
+                            close={closeModal}
+                            message={message}
+                            onConfirm={() => navigate('/createteam')}
+                            isOkConfirm={isOkModal}
+                        />
+                    </Box>
+                </Box>
+                <Box>
                 </Box>
                 <Box className="YoutubePlayerPosition">
                     <iframe

--- a/src/combined/ClientApp/src/Pages/Home/Home.tsx
+++ b/src/combined/ClientApp/src/Pages/Home/Home.tsx
@@ -110,6 +110,12 @@ export function Home() {
         setOpenConfrimModal(true)
         setMessage("Are you sure you want to create a new team? This will remove you from the current team you are on.")
     }
+    const messageArray: string[] = [
+        `Event: ${currentEvent?.title}. `,
+        ` Location: ${currentEvent?.location}. `,
+        ` Description: ${currentEvent?.description}`,
+    ]
+    const displayMessage: string = messageArray.join('\n')
     
 
     const getDonationTotal = useCallback(async () => {
@@ -167,12 +173,7 @@ export function Home() {
                         <Button variant='contained'
                             className = "EventDetailsButton"
                             onClick={() => {
-                                setMessage("Event: " + currentEvent?.title + "," +
-                                        " Location: " + 
-                                    currentEvent?.location + "," +
-                                    " Description: " + 
-                                    currentEvent?.description
-                                    )
+                                setMessage(displayMessage);
                                 setIsOkModal(true)
                                 setOpenEventDetailsOkModal(true)
                             }}>

--- a/src/combined/ClientApp/src/components/TeamsInfo/LoggedInUser.tsx
+++ b/src/combined/ClientApp/src/components/TeamsInfo/LoggedInUser.tsx
@@ -6,6 +6,7 @@ import { Col, Form, FormGroup, Input, Label, Row, FormText } from "reactstrap";
 import { EventContext } from "../../App";
 import DynamicModal from "../DynamicModal";
 import Team from "../../JsModels/team";
+import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
 
 
 export function LoggedInUser() {
@@ -155,7 +156,11 @@ export function LoggedInUser() {
 
     return (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <Button variant='contained' className="NickNameBackButton" onClick={() => navigate(-1)}>Back</Button>
+            <Button
+                onClick={() => navigate(-1)}
+            >
+                <KeyboardBackspaceIcon className="BackToTeamsListButton" />
+            </Button>
             <Form onSubmit={addTeamMemberHandler} style={{ width: '90vw', border: 'solid #673ab7', borderRadius: '30px' }}>
                 <Row style={{ display: 'flex', justifyContent: 'center' }}>
                     <Col md={6} xs={8}>

--- a/src/combined/ClientApp/src/components/TeamsInfo/TeamDetails.tsx
+++ b/src/combined/ClientApp/src/components/TeamsInfo/TeamDetails.tsx
@@ -279,7 +279,7 @@ export function TeamDetails() {
                         (<Button
                             onClick={() => {
                                 setOpenSwitchTeamsModal(true);
-                                setMessage("Are you sure you want to leave" + loggedInUserTeamId + "to switch teams to " + currentTeam?.name + "?")
+                                setMessage("Are you sure you want to leave " + loggedInUserTeamId + " to switch teams to " + currentTeam?.name + "?")
                             }
                             }
                             className="SwitchTeamsButton"

--- a/src/combined/ClientApp/src/components/TeamsInfo/TeamDetails.tsx
+++ b/src/combined/ClientApp/src/components/TeamsInfo/TeamDetails.tsx
@@ -279,7 +279,7 @@ export function TeamDetails() {
                         (<Button
                             onClick={() => {
                                 setOpenSwitchTeamsModal(true);
-                                setMessage("Are you sure you want to switch teams to " + currentTeam?.name + "?")
+                                setMessage("Are you sure you want to leave" + loggedInUserTeamId + "to switch teams to " + currentTeam?.name + "?")
                             }
                             }
                             className="SwitchTeamsButton"


### PR DESCRIPTION
There is a back arrow now on the nickname page, there is a modal that shows the event details once you click a button for event details. It is also styled the way that all the buttons are. The modal doesn't have any new lines though and I have tried every possible technique and it doesn't work. They will just have to deal with that unless someone else wants to make a new modal for it. Finally, When you switch teams, you can see in the modal the team you are switching from to the team you're switching to.